### PR TITLE
Prefer error.name over constructor.name

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -59,7 +59,7 @@ function Error(error, errorClass) {
         this.errorClass = errorClass || "Error";
     } else if (error) {
         this.message = error.message;
-        this.errorClass = errorClass || error.constructor.name || error.name || "Error";
+        this.errorClass = errorClass || error.name || error.constructor.name || "Error";
     } else {
         this.message = "[unknown]";
         this.errorClass = errorClass || "Error";


### PR DESCRIPTION
Simplest way to create a custom Error class in Javascript is to modify the name property of the error instance. With the previous implementation the bugsnag error code would prefer the constructor's name (which is always "Error") over the custom error name which is the desired one.

This change just switches them around so the error.name is considered first and should be the source of truth, and only if it's not defined should fallback to constructor.name. 

The previous way made it difficult to work with error libraries like: https://github.com/jshttp/http-errors

Also worth mentioning: the bugsnag notify does allow you to specify a custom errorClass in the function call but it can't be used with, for example, the express errorHandler as it captures the errors automatically.